### PR TITLE
Teach kerodon how to deal with non-string response bodies

### DIFF
--- a/src/kerodon/impl.clj
+++ b/src/kerodon/impl.clj
@@ -1,6 +1,7 @@
 (ns kerodon.impl
   (:require [net.cgrand.enlive-html :as enlive]
-            [clojure.string :as string])
+            [clojure.string :as string]
+            [clojure.java.io :as io])
   (:import java.io.StringReader))
 
 ;; selectors
@@ -67,11 +68,22 @@
 
 ;; state manipulation
 
+
+(defprotocol ToHtmlResource
+  (to-html-resource [obj]))
+
+(extend-protocol ToHtmlResource
+  clojure.lang.ISeq
+  (to-html-resource [s]  (to-html-resource (apply str s)))
+  String
+  (to-html-resource [str] (enlive/html-resource (StringReader. str)))
+  Object
+  (to-html-resource [o] (enlive/html-resource o)))
+
 (defn include-parse [state]
   (assoc state
     :enlive (when-let [body (:body (:response state))]
-              (enlive/html-resource
-               (StringReader. body)))))
+              (to-html-resource body))))
 
 ;TODO: merge w/ peridot
 (defn build-url

--- a/test/kerodon/unit/impl.clj
+++ b/test/kerodon/unit/impl.clj
@@ -1,0 +1,19 @@
+(ns kerodon.unit.impl
+  (:use [kerodon.impl]
+        [clojure.test])
+  (:require [net.cgrand.enlive-html :as enlive])
+  (:import java.io.StringReader))
+
+(deftest test-to-html-resource
+  "The Ring spec specifies that the response :body can be:
+
+ {String, ISeq, File, InputStream}
+
+So, make sure to-html-resource can handle all these cases. Enlive knows how to read
+files and input streams, and those are hard to create in test cases, so don't test those."
+  (let [html "<html><body><h1>Don Kero</h1></body></html>"
+        expected (enlive/html-resource (StringReader. html))]
+    (testing "String"
+      (is (= expected (to-html-resource html))))
+    (testing "LazySeq"
+      (is (= expected (to-html-resource (map identity ["<html>" "<body>" "<h1>" "Don Kero" "</h1>" "</body>" "</html>"])))))))


### PR DESCRIPTION
It would explode passing the body to StringReader's constructor
before, which is not super ideal
