### PR TITLE
Resolve visit URI against URI of last request

### DIFF
--- a/src/kerodon/core.clj
+++ b/src/kerodon/core.clj
@@ -4,8 +4,13 @@
 
 (def session peridot/session)
 
-(defn visit [state & rest]
-  (impl/include-parse (apply peridot/request state rest)))
+(defn- resolve-uri [state uri]
+  (if-let [request (:request state)]
+    (str (.resolve (java.net.URI. (peridot.request/url request)) uri))
+    uri))
+
+(defn visit [state uri & rest]
+  (impl/include-parse (apply peridot/request state (resolve-uri state uri) rest)))
 
 (defn follow-redirect [state]
   (impl/include-parse (peridot/follow-redirect state)))

--- a/test/kerodon/unit/core.clj
+++ b/test/kerodon/unit/core.clj
@@ -2,7 +2,8 @@
   (:use [kerodon.core]
         [clojure.test]
         [kerodon.test])
-  (:require [net.cgrand.moustache :as moustache]
+  (:require [peridot.request :as request]
+            [net.cgrand.moustache :as moustache]
             [ring.util.response :as response]
             [ring.middleware.params :as params]
             [ring.middleware.session :as session]
@@ -46,7 +47,21 @@
                        :scheme :http
                        :request-method :get
                        :headers {"host" "localhost"}}]
-          (is (= request (:request state))))))))
+          (is (= request (:request state)))))
+      (testing "resolves relative links against the URI of the last request"
+        (-> (session #(response/response (request/url %)))
+            (visit "http://example.com/foo/bar")
+            (has (text? "http://example.com/foo/bar"))
+            (visit "/fuz/buz")
+            (has (text? "http://example.com/fuz/buz"))
+            (visit "cats")
+            (has (text? "http://example.com/fuz/cats"))
+            (visit "/dogs/")
+            (has (text? "http://example.com/dogs/"))
+            (visit "fish")
+            (has (text? "http://example.com/dogs/fish"))
+            (visit "https://www.example.com/carbs")
+            (has (text? "https://www.example.com/carbs")))))))
 
 (defn test-follow-method [state selector]
   (let [state (follow state selector)]


### PR DESCRIPTION
This is what a browser would do, and it allows users to set a
non-localhost hostname at the beginning of tests and get correct
cookie behavior. Previously, a cookie set in a request to
http://example.com/foo would not be available when kerodon followed a
relative link on that page because the absence of an explicit hostname
in the link would result in `localhost` being used as the hostname for
that request.
