### PR TITLE
ignore whitespaces in content checks

### DIFF
--- a/src/kerodon/impl.clj
+++ b/src/kerodon/impl.clj
@@ -24,7 +24,7 @@
 
 (defn css-or-content [selector]
   (if (string? selector)
-    (enlive/pred #(= (:content %) [selector]))
+    (enlive/pred #(= (map clojure.string/trim (:content %)) [selector]))
     selector))
 
 (defn css-or-label [selector]

--- a/test/kerodon/unit/core.clj
+++ b/test/kerodon/unit/core.clj
@@ -83,10 +83,13 @@
 (deftest test-follow
   (testing "follow by link"
     (let [state {:app (constantly :x)
-                 :enlive (parse [:a {:id "go-login"
-                                     :href "/login"} "login"])}]
+                 :enlive (parse [:div {} 
+                                 [:a {:id "go-login" :href "/login"} "login"]
+                                 [:a {:href "/login"} "   \n link with whitespaces \n "]])}]
       (testing "text"
         (test-follow-method state "login"))
+      (testing "text with whitespaces"
+        (test-follow-method state "link with whitespaces"))
       (testing "css"
         (test-follow-method state :#go-login))
       (testing "not found throws exception"


### PR DESCRIPTION
Depending on the way of html generation sometimes whitespaces are contained in the tag contents. But when testing for tag content leading and trailing whitespaces should be ignored.
