### PR TITLE
Improve regex? example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ You can use ```attr?``` to validate an attribute's value.
          "page is found")
     (has (text? "hello world")
          "page says hello world")
-    (has (regex? ".*world.*")
+    (has (regex? "(?s).*world.*") ; NOTE: (?s) to match multiline
          "page includes 'world'"))
 
 (-> (session ring-app)


### PR DESCRIPTION
Add (?s) to regex to explicitly indicate to the users that it is needed to match multiline
