### PR TITLE
 Optionally squash HTML content on to a single line before validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,11 @@ The main function is ```has```.  It allows the verifications to compose using ->
 You can use ```status?``` to validate the status code of the last response.
 You can use ```text?``` or ```regex?``` to validate the text in the page/element.
 You can use ```some-text?``` or ```some-regex?``` to look for text anywhere in the page/element.
+Note that for all of ```text?```, ```regex?```, ```some-text?```, and
+```some-regex?``` tests replace all one or more consecutive whitespace
+characters (i.e., ' ', '\t', '\n', etc.) in the text of the page/element with a
+single space.  This feature allows the tests to ignore line breaks and spacing
+issues in the source text.
 You can use ```value?``` to validate the value of a field.  The
 selector can be the text or css of a label with a for element, or the
 css of the field itself.

--- a/test/kerodon/unit/test.clj
+++ b/test/kerodon/unit/test.clj
@@ -93,6 +93,19 @@
                        :expected '(text? "yes")
                        :actual "yes"}
                       #(text? "yes")
+                      state)))
+    (let [state {:enlive (parse [:p "yes  sir\n\n\nyes"])}]
+      (testing "fails an exact match due to significant whitespace"
+        (check-report {:type     :fail
+                       :expected '(text? "yes  sir\n\n\nyes")
+                       :actual   "yes sir yes"}
+                      #(text? "yes  sir\n\n\nyes")
+                      state))
+      (testing "passes if text is identical after unwrapping lines"
+        (check-report {:type     :pass
+                       :expected '(text? "yes sir yes")
+                       :actual   "yes sir yes"}
+                      #(text? "yes sir yes")
                       state)))))
 
 (deftest test-some-text?
@@ -147,6 +160,19 @@
                        :expected '(some-regex? "\\d{5}")
                        :actual "Account Number: #12345"}
                       #(some-regex? "\\d{5}")
+                      state)))
+    (let [state {:enlive (parse [:p "yes  sir\n\n\nyes"])}]
+      (testing "fails due to significant whitespace"
+        (check-report {:type     :fail
+                       :expected '(some-regex? "sir\\s{3}yes")
+                       :actual   "yes sir yes"}
+                      #(some-regex? "sir\\s{3}yes")
+                      state))
+      (testing "passes due to collapsed whitespace"
+        (check-report {:type     :pass
+                       :expected '(some-regex? "sir\\s{1}yes")
+                       :actual   "yes sir yes"}
+                      #(some-regex? "sir\\s{1}yes")
                       state)))))
 
 (deftest test-attr?


### PR DESCRIPTION
HTML content usually spans multiple lines, with linebreaks and whitespaces
being insignificant. However, `text?`, `regex?`, `some-text?`, `some-regex?`
apply their validations rigidly. As such, these checks are fragile -- for
instance, if someone changes the template file of the underlying content, the
tests may fail. With this changeset, the user can provide an option
`:unwrap-lines` to make such checks less rigid, and thus, making the tests more
robust.

======
#### Question for pull request reviewers 

I personally think `:unwrap-lines` is a better default, while providing `:keep-as-is` as an option. However, for the sake of current users of the library, I kept the default behavior as is. Let me know what you think.
