### PR TITLE
Update dependancies to the latest stable

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [peridot "0.4.0"]
                  [enlive "1.1.6" :exclusions [org.clojure/clojure]]
-                 [ring/ring-codec "1.0.0"]
+                 [ring/ring-codec "1.0.1"]
                  [org.flatland/ordered "1.5.3"]]
   :profiles {:test {:dependencies [[net.cgrand/moustache "1.1.0"
                                     :exclusions

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [peridot "0.4.0"]
+                 [peridot "0.4.4"]
                  [enlive "1.1.6" :exclusions [org.clojure/clojure]]
                  [ring/ring-codec "1.0.1"]
                  [org.flatland/ordered "1.5.4"]]

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
                  [peridot "0.4.0"]
                  [enlive "1.1.6" :exclusions [org.clojure/clojure]]
                  [ring/ring-codec "1.0.1"]
-                 [org.flatland/ordered "1.5.3"]]
+                 [org.flatland/ordered "1.5.4"]]
   :profiles {:test {:dependencies [[net.cgrand/moustache "1.1.0"
                                     :exclusions
                                     [[org.clojure/clojure]

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
                                     :exclusions
                                     [[org.clojure/clojure]
                                      [ring/ring-core]]]
-                                   [ring/ring-core "1.4.0"]
+                                   [ring/ring-core "1.5.0"]
                                    [javax.servlet/servlet-api "2.5"]
                                    [hiccup "1.0.5"]]
                     :resource-paths ["test-resources"]}

--- a/test/kerodon/unit/core.clj
+++ b/test/kerodon/unit/core.clj
@@ -213,7 +213,7 @@
                                    :content '("File")}
                                   {:tag :input
                                    :attrs {:value (proxy [java.io.File]
-                                                    ["file"])
+                                                    ["test-resources/file.txt"])
                                            :type "file"
                                            :name "file"
                                            :id "file-id"}


### PR DESCRIPTION
Hello,

kerodon is pretty cool, but some of the dependancies got out of date.

Here is my PR where I've updated all the dependencies to the latest stable releases.

The only little "issue" was with the peridot's update in https://github.com/xeqi/kerodon/commit/ae9e84a5d30fd343e1ff89a0a9742ee0ac46b338#diff-a25aa8b24602af3c7784bd4ab0d9dfe4R216 , where a real file path had to be supplied, as well as bumping up the version number.

Thank you